### PR TITLE
refactor: shrink npm package size

### DIFF
--- a/common/bundestagio/package.json
+++ b/common/bundestagio/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.0",
+    "ts-unused-exports": "^6.2.4",
     "typescript": "^3.9.5"
   },
   "dependencies": {
@@ -25,7 +26,6 @@
     "mongoose": "^5.10.9",
     "mongoose-diff-history": "^2.1.0",
     "omit-deep": "^0.3.0",
-    "ts-mongoose": "^0.0.21",
-    "ts-unused-exports": "^6.2.4"
+    "ts-mongoose": "^0.0.21"
   }
 }


### PR DESCRIPTION
## Pullrequest
`ts-unused-exports` is certainly a development dependency. Pretty much
everywhere this leads to unnecessary large builds and docker images.

### Issues

Reduced size is 54MB(!)


<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Env-Variables adjustment needed
- [ ] Breaking/critical change
-->
- [X] None

### Repositories Affected
<!-- Did you update any Submodules? -->
- [x] bundestag.io
- [ ] bundestag.io-admin
- [ ] client
- [ ] democracy-app.de
- [x] democracy-app.de-api
- [ ] democracy-app.de-admin
- [ ] democracy-deutschland.de
- [ ] docu
- [ ] elasticsearch
- [X] None

### How2Test

```
robert@t14 ~/D/d/d/c/bundestagio ((9cde9cae…))> yarn install --production
yarn install v1.22.10
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 0.94s.
robert@t14 ~/D/d/d/c/bundestagio ((9cde9cae…))> du -sh node_modules/
135M	node_modules/
robert@t14 ~/D/d/d/c/bundestagio ((9cde9cae…))> git checkout -
Previous HEAD position was 9cde9ca Merge pull request #413 from demokratie-live/feature/1339-broken-share-links
Switched to branch 'master'
Your branch is ahead of 'origin/master' by 1 commit.
  (use "git push" to publish your local commits)
robert@t14 ~/D/d/d/c/bundestagio (master)> rm -rf node_modules/
robert@t14 ~/D/d/d/c/bundestagio (master)> yarn install --production
yarn install v1.22.10
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 0.67s.
robert@t14 ~/D/d/d/c/bundestagio (master)> du -sh node_modules/
81M	node_modules/
```

### Todo
<!-- In case some parts are still missing, list them here.
- [ ] Todo1
- [ ] Todo2
-->
- [X] None
