### PR TITLE
Build Bundestag.io-api action trigger verringert

### DIFF
--- a/.github/workflows/bundestag.io-api--build-and-push.yaml
+++ b/.github/workflows/bundestag.io-api--build-and-push.yaml
@@ -9,6 +9,8 @@ on:
     tags:
       - 'v*'
   pull_request:
+    paths:
+      - "bundestag.io-api/**"
     branches:
       - 'master'
 

--- a/.github/workflows/bundestag.io-api--build-and-push.yaml
+++ b/.github/workflows/bundestag.io-api--build-and-push.yaml
@@ -2,6 +2,8 @@ name: bundestag.io-api/ Build and Push Docker Image
 
 on:
   push:
+    paths:
+      - "bundestag.io-api/**"
     branches:
       - 'master'
     tags:


### PR DESCRIPTION
Derzeit läuft die action https://github.com/demokratie-live/democracy-development/blob/6039ba5e0ba32b7ae1aa90e64bf82d9e5ca8e64e/.github/workflows/bundestag.io-api--build-and-push.yaml zu oft. 
Hiermit läuft die action nur noch wenn sich auch innerhalb des Ordners `bundestag.io-api` eine Änderung passiert.