### PR TITLE
refactor(test): remove supertest dependency

### DIFF
--- a/bundestag.io/dip/package.json
+++ b/bundestag.io/dip/package.json
@@ -21,7 +21,6 @@
     "@types/pollyjs__adapter-node-http": "^2.0.1",
     "@types/pollyjs__persister-fs": "^2.0.1",
     "@types/setup-polly-jest": "^0.5.1",
-    "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.0",
     "eslint": "^7.29.0",
@@ -30,7 +29,6 @@
     "jest": "^27.0.4",
     "prettier": "2.3.1",
     "setup-polly-jest": "^0.9.1",
-    "supertest": "^6.1.3",
     "ts-jest": "^27.0.3",
     "ts-node-dev": "^1.1.6",
     "typescript": "^4.3.2"

--- a/bundestag.io/dip/src/server.spec.ts
+++ b/bundestag.io/dip/src/server.spec.ts
@@ -1,6 +1,6 @@
 /** @jest-environment setup-polly-jest/jest-environment-node */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { setupPolly } from 'setup-polly-jest';
-import supertest from 'supertest';
 import createServer from './server';
 import NodeHTTPAdapter from '@pollyjs/adapter-node-http';
 import FSPersister from '@pollyjs/persister-fs';
@@ -19,17 +19,9 @@ const context = setupPolly({
 const randomObjects = (n: number) => Array.from(Array(n).keys()).map(() => expect.any(Object));
 
 const DIP_API_KEY = 'N64VhW8.yChkBUIJeosGojQ7CSR2xwLf3Qy7Apw464';
-const { app } = createServer({ DIP_API_KEY, DIP_API_ENDPOINT: 'https://search.dip.bundestag.de', RATE_LIMIT: 20 });
-
-const request = supertest(app);
+const { server } = createServer({ DIP_API_KEY, DIP_API_ENDPOINT: 'https://search.dip.bundestag.de', RATE_LIMIT: 20 });
 
 const gql = String.raw;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const runQuery = async ({ query, variables }: { query: string; variables?: Record<string, unknown> }): Promise<any> => {
-  const res = await request.post('/').send({ query, variables }).set('Accept', 'application/json').expect(200);
-  return JSON.parse(res.text);
-};
 
 describe('Query', () => {
   beforeEach(() => {
@@ -92,7 +84,7 @@ describe('Query', () => {
 
     it('returns gestOrderNumber', async () => {
       const variables = { procedureId: '275933' };
-      await expect(runQuery({ query, variables })).resolves.toMatchObject({
+      await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
         data: {
           procedure: {
             procedureId: '275933',
@@ -106,7 +98,7 @@ describe('Query', () => {
 
     it('returns legalValidity', async () => {
       const variables = { procedureId: '155381' };
-      await expect(runQuery({ query, variables })).resolves.toMatchObject({
+      await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
         data: {
           procedure: {
             procedureId: '155381',
@@ -122,7 +114,7 @@ describe('Query', () => {
     describe('history', () => {
       it('returns assignment+initiator', async () => {
         const variables = { procedureId: '234344' };
-        await expect(runQuery({ query, variables })).resolves.toMatchObject({
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
           data: {
             procedure: {
               procedureId: '234344',
@@ -146,7 +138,7 @@ describe('Query', () => {
 
       it('returns findSpot+findSpotUrl', async () => {
         const variables = { procedureId: '234344' };
-        await expect(runQuery({ query, variables })).resolves.toMatchObject({
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
           data: {
             procedure: {
               procedureId: '234344',
@@ -179,7 +171,7 @@ describe('Query', () => {
 
       it('returns date', async () => {
         const variables = { procedureId: '234344' };
-        await expect(runQuery({ query, variables })).resolves.toMatchObject({
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
           data: {
             procedure: {
               procedureId: '234344',
@@ -198,7 +190,7 @@ describe('Query', () => {
       describe('decision', () => {
         it('returns page+tenor+document+type+comment', async () => {
           const variables = { procedureId: '234344' };
-          await expect(runQuery({ query, variables })).resolves.toMatchObject({
+          await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
             data: {
               procedure: {
                 procedureId: '234344',
@@ -234,7 +226,7 @@ describe('Query', () => {
 
         it('returns foundation', async () => {
           const variables = { procedureId: '233294' };
-          await expect(runQuery({ query, variables })).resolves.toMatchObject({
+          await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
             data: {
               procedure: {
                 procedureId: '233294',
@@ -260,7 +252,7 @@ describe('Query', () => {
 
         it('returns majority', async () => {
           const variables = { procedureId: '44236' };
-          await expect(runQuery({ query, variables })).resolves.toMatchObject({
+          await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
             data: {
               procedure: {
                 procedureId: '44236',
@@ -328,7 +320,7 @@ describe('Query', () => {
             data: {
               procedures: { edges },
             },
-          } = await runQuery({ query, variables });
+          }: any = await server.executeOperation({ query, variables });
           expect(edges).toHaveLength(17);
         });
       });
@@ -342,7 +334,7 @@ describe('Query', () => {
             data: {
               procedures: { edges },
             },
-          } = await runQuery({ query, variables });
+          }: any = await server.executeOperation({ query, variables });
           expect(edges).toHaveLength(50);
           expect(edges).toMatchObject([
             expect.objectContaining({ node: { procedureId: '279259' } }),
@@ -354,7 +346,7 @@ describe('Query', () => {
 
         it('limit must be divisible of 50', async () => {
           const variables = { limit: 3 };
-          await expect(runQuery({ query, variables })).resolves.toMatchObject({
+          await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
             data: { procedures: null },
             errors: [
               expect.objectContaining({
@@ -372,7 +364,7 @@ describe('Query', () => {
               data: {
                 procedures: { edges },
               },
-            } = await runQuery({ query, variables });
+            }: any = await server.executeOperation({ query, variables });
             const idSet = new Set(edges.map((edge: { node: { procedureId: number } }) => edge.node.procedureId));
             expect(edges).toHaveLength(100);
             expect(idSet.size).toEqual(100);
@@ -384,7 +376,7 @@ describe('Query', () => {
               data: {
                 procedures: { edges },
               },
-            } = await runQuery({ query, variables });
+            }: any = await server.executeOperation({ query, variables });
             const idSet = new Set(edges.map((edge: { node: { procedureId: number } }) => edge.node.procedureId));
             expect(edges).toHaveLength(2);
             expect(idSet.size).toEqual(2);
@@ -398,7 +390,7 @@ describe('Query', () => {
             data: {
               procedures: { edges },
             },
-          } = await runQuery({
+          }: any = await server.executeOperation({
             query,
             variables: {
               filter: { after: '2021-06-14', before: '2021-06-18' },
@@ -417,14 +409,14 @@ describe('Query', () => {
             data: {
               procedures: { edges },
             },
-          } = await runQuery({
+          } = (await server.executeOperation({
             query,
             variables: {
               filter: { after: '2021-06-14', before: '2021-06-18' },
               offset: 2,
               limit: 50,
             },
-          }));
+          })) as any);
           expect(edges).toHaveLength(50);
           expect(edges).toMatchObject([
             expect.objectContaining({ node: { procedureId: '279257' } }),
@@ -442,7 +434,7 @@ describe('Query', () => {
             data: {
               procedures: { edges },
             },
-          } = await runQuery({ query, variables });
+          }: any = await server.executeOperation({ query, variables });
           expect(edges).toHaveLength(50);
           expect(edges).toMatchObject([
             expect.objectContaining({ node: { procedureId: '277500' } }),
@@ -457,7 +449,7 @@ describe('Query', () => {
     describe('pageInfo', () => {
       it('maps to numFound', async () => {
         const variables = { before: '2021-06-18' };
-        await expect(runQuery({ query, variables })).resolves.toMatchObject({
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
           data: {
             procedures: {
               totalCount: 277499,
@@ -468,7 +460,7 @@ describe('Query', () => {
 
       it('hasNextPage indicates if there are more entries', async () => {
         const variables = { filter: { before: '1970-01-01' } };
-        await expect(runQuery({ query, variables })).resolves.toMatchObject({
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
           data: {
             procedures: {
               pageInfo: {

--- a/bundestag.io/dip/yarn.lock
+++ b/bundestag.io/dip/yarn.lock
@@ -805,11 +805,6 @@
   resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.3.tgz#0aa116701955c2faa0717fc69cd1596095e49d96"
   integrity sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg==
 
-"@types/cookiejar@*":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
-  integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
-
 "@types/cookies@*":
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.6.tgz#71212c5391a976d3bae57d4b09fac20fc6bda504"
@@ -1043,21 +1038,6 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
-
-"@types/superagent@*":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.11.tgz#4822bc64a82a0f579261a77097dbca276556c20e"
-  integrity sha512-cZkWBXZI+jESnUTp8RDGBmk1Zn2MkScP4V5bjD7DyqB7L0WNWpblh4KX5K/6aTqxFZMhfo1bhi2cwoAEDVBBJw==
-  dependencies:
-    "@types/cookiejar" "*"
-    "@types/node" "*"
-
-"@types/supertest@^2.0.11":
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-2.0.11.tgz#2e70f69f220bc77b4f660d72c2e1a4231f44a77d"
-  integrity sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==
-  dependencies:
-    "@types/superagent" "*"
 
 "@types/ws@^7.0.0":
   version "7.4.4"
@@ -1894,11 +1874,6 @@ commander@^2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-component-emitter@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1932,11 +1907,6 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
-
-cookiejar@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
-  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 core-js-pure@^3.10.2:
   version "3.14.0"
@@ -2486,11 +2456,6 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-safe-stringify@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
-  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
-
 fastq@^1.6.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.0.tgz#bb9fb955a07130a918eb63c1f5161cc32a5d0858"
@@ -2576,11 +2541,6 @@ form-data@^3.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
-
-formidable@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
-  integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -2911,7 +2871,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3780,7 +3740,7 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@^1.1.2, methods@~1.1.2:
+methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -3809,11 +3769,6 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-
-mime@^2.4.6:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
-  integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -4230,7 +4185,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.7.0, qs@^6.9.4:
+qs@^6.7.0:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
@@ -4283,15 +4238,6 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
-
-readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
 
 readdirp@~3.5.0:
   version "3.5.0"
@@ -4401,7 +4347,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -4651,13 +4597,6 @@ string.prototype.trimstart@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 strip-ansi@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
@@ -4714,31 +4653,6 @@ subscriptions-transport-ws@^0.9.19:
     iterall "^1.2.1"
     symbol-observable "^1.0.4"
     ws "^5.2.0 || ^6.0.0 || ^7.0.0"
-
-superagent@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-6.1.0.tgz#09f08807bc41108ef164cfb4be293cebd480f4a6"
-  integrity sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==
-  dependencies:
-    component-emitter "^1.3.0"
-    cookiejar "^2.1.2"
-    debug "^4.1.1"
-    fast-safe-stringify "^2.0.7"
-    form-data "^3.0.0"
-    formidable "^1.2.2"
-    methods "^1.1.2"
-    mime "^2.4.6"
-    qs "^6.9.4"
-    readable-stream "^3.6.0"
-    semver "^7.3.2"
-
-supertest@^6.1.3:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.1.3.tgz#3f49ea964514c206c334073e8dc4e70519c7403f"
-  integrity sha512-v2NVRyP73XDewKb65adz+yug1XMtmvij63qIWHZzSX8tp6wiq6xBLUy4SUAd2NII6wIipOmHT/FD9eicpJwdgQ==
-  dependencies:
-    methods "^1.1.2"
-    superagent "^6.1.0"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -5033,11 +4947,6 @@ utf8-byte-length@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
   integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
-
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util.promisify@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
I figured out, this dependency is actually not necessary for what we try
to test:
https://www.apollographql.com/docs/apollo-server/testing/testing/

The only bummer is that we'd have to cast the returned type to `any`.

## Pullrequest

<!-- Describe the Pullrequest. -->

### Issues

<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->

- [x] None

### Checklist

<!-- Anything important to be thought of when deploying?
- [ ] Env-Variables adjustment needed
- [ ] Breaking/critical change
-->

- [x] None

----

merge before #455
