### PR TITLE
fix: strip HTML from abstract

### DIFF
--- a/bundestag.io/dip/__recordings__/Query_2659837827/procedure_2800173518/removes-HTML-from-abstract_67491429/recording.har
+++ b/bundestag.io/dip/__recordings__/Query_2659837827/procedure_2800173518/removes-HTML-from-abstract_67491429/recording.har
@@ -1,0 +1,241 @@
+{
+  "log": {
+    "_recordingName": "Query/procedure/removes HTML from `abstract`",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "5.1.1"
+    },
+    "entries": [
+      {
+        "_id": "8e22a4e0463e1531e086ce2c7d248f40",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 298,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://search.dip.bundestag.de/api/v1/vorgang/275942"
+        },
+        "response": {
+          "bodySize": 518,
+          "content": {
+            "_isBinary": true,
+            "mimeType": "application/json",
+            "size": 518,
+            "text": "[\"1f8b08000000000000009d93cf6ed43010c65fc5f2a995d23f1b5ad0ae2aa456203871684539a01e9ccdc4193571569ec9aed8aa371e8567e0c46d5fac9f93455c60857288648fc7bff9fccde4c9726917367f7339bfc86d665d211add5211bbc2aa0bfeed0dc9b26e7a116a57156115bc2949cc3542cb3ac5657175b64f36bbefa1a4881c0ac015149d6223a22ea442373d8e054153e3bba7d8b26a428afb8d338197b51a0744ecab01b3eea2c75ef4db0a8c0f24a45b4f05aee1d013e0093d7b7589adb8658d3326bce1abbd25b010bd53877a289e6a6e5c9344d987cc8ec4fb918fbc8dab9b1545ee4ab28bd93cb3db5e94db36292ca8ec2956cafe9178a07f220e99695caf66144541377dacccd1bb2826bf989fe5337354909c1237b87e7a7c9c8a726065a7bca604d95b429e07df524209d3dad496f37c7672fefa244f0f53566a9258e429fc1f2b9a6d1fff983e346678ab24ffeaddcf38aa153fea138090f31879a55d44f9275ba1be00dd404de51aa1cc06d76263afcb6ea5dca50e8c3eddc1db827ce4aa22fb9c1dbc1b94313178a8b4bd4c22a4e66b8d5ec99a6217cb30f67b040d8d95d6299ae51ac6981ca6bde750ec7e453f7a3c41ce4727c9b69603cae9ee874e81dc0232d990bff5f5ff381afbc398fd784c76f70b1306d0f7da42469ac3e0d2e020a7db2600fe21fcdc14cce71007f43f743f3cbf006bc7de8e91040000\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 27 Jul 2021 17:34:52 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-transform, max-age=300"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "content-length",
+              "value": "518"
+            },
+            {
+              "name": "via",
+              "value": "1.1 search.dip.bundestag.de"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "origin, x-requested-with, content-type, authorization, content-disposition, accept"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "OPTIONS,GET,PUT,POST,DELETE,HEAD"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 649,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-27T17:34:44.050Z",
+        "time": 115,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 115
+        }
+      },
+      {
+        "_id": "22529e08fc04f0ff4bcd0cbaa78d9847",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 317,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "f.vorgang",
+              "value": "275942"
+            }
+          ],
+          "url": "https://search.dip.bundestag.de/api/v1/vorgangsposition?f.vorgang=275942"
+        },
+        "response": {
+          "bodySize": 4686,
+          "content": {
+            "_isBinary": true,
+            "mimeType": "application/json",
+            "size": 4686,
+            "text": "[\"1f8b0800000000000000ed5bcd6edb48127e9506f79200b2cd3f91a66f92e5384ec61ec376b28b1d18414b6c8a84c8a6b6d9f46015f8b68f31c05e0cec1bcc29a7d18b6d7593a2488994f5e70d36e38b63f70febebaeaaafaaab3b5f159a46efe294baca8966b614371ea411a13c514e7ef9aa04d0aab48f1dd5319496f210b321a6c3641c27010f620a7de724217c02e37f4d9907432669cc5c9ad221f4756fa0414c504e384b494bf162c6c570d9ede13081368a073e6778de3013c2ff392ebe3f247d31a7a5648d9f17714047c04928ba02c2384950360f4d5286a6ffa22e61301fb9d071cb31e609cc26fef477160c4724e0c9305b45021fc2231e3c041c13fe05d309f6e1a3aad89591dc15cc3808e9b174304a0038996fca17b955badd764c1d5a5dccd34834a8ba76a01a07ba058d1eec72023843a29c7c55c6aef7256502b4cff93839393a7213c21e083b84c502548e87872e39ea33f7487ce548d54de740d70e611e7c2b13d7d635eb5899e3035d4684891ed339d2b526202b96e3167f94153057b04f184e61c3fa528c5471cafceccf5f94ae44cec830903baedc3fb6144692241682c09e3c02aaf052e233220c2e338b99eeb2c9514003d82416a49154d805a584d116f2a6df18eae214c128f49e0411e6cae33d4817b27f254122ad0a6400bc64e0c30ff86467f67b365d7e8ba00e683f2443427d503e11e653ccf9324a099b483817a2630e389dd9f1636ba58c0eebc3575b208b9321c3c23e25e4db7812e0701c8760b2a306919d8bdb6599d22fe44a8b7dfeaa9080f65900eb6085e3f4c9840403bf70bea1b2b8b573bd3cde8b5564deeda8a6e16ce1dd77afde9d399579a0395b7b37778f3470d5630bfe819fb6b9e0dfb6ddaef3ef6c8e6d368179101b1584b57dfbf3febbefeffd2fe4139aa159f53e71168d3de28730835080080e2f1d79fa2d49485d00c4fd043c6020b6bab0d504be0b73c2e9d390145e9443fe13bb916eec27486a4b61d2581126b5ba409983d9c055ca76f15c9cbc7f2c9b9ae934989a7688baf0199ea9f547245f7b718baf4342311bb398c7a3380cd7371d7d490009c0b9042f2422ca8bb1c76ddbe856c62599d41b20a6d24adf937048d04f0175fd16ba74bb2d747bdd83feb5397d2c381df85c976cfe97eb43295a114a2f83314fd700d36387e83ce6dc630171d169ca823807d5f17607652e816af7d600f52e088309ba8e43cc7330dde96f57bdab8b5be4a847bd8b33747e030d67573b036c2f00b434ad5185e8cd2445d733db414322dc8fbe2de1be84608049883ea69e47580efdb4f7e9e8f4f6d38e5001988c487d22981d6282879322272d1a21dd8c05214c7f2b65adabe37b59395657cad832d56830cb9c25dba65acb91028a5e9768489f6b4834747b893d975d7b653601cbc4d4135c946f8004db522075283558c5a87fa4d865980a49c2406058a5e5719b9342524e379a4e0994d0ce5627854b42e14f4219019e2652949f4698067cfa04a794f741e891a68382574c6e3a30ac967d23644a919f09eb831ae05b222549f9a451a49c03c31b8f28a5a0a65b7a43c500825a2f65035f46af1fb360a0ed27aab50f54fbf9a8a639f61a842da2c88718b62e88c48aa2b1e4be1bf4e6324fb833b3f81888a5b7d03b1c01c313f8259c7e83fd0e455a2dcda574ac7ddb4257a03cf0d8801efc1578061422739fb593362024559d919158c8fa047a2be80f7a29f62372821a536b6873432cf64ce9307e886c0b75fac921d2d1f9f9cac2c97c7f8f77e0dce525166cab99b56c0ba39b2c61433ebd59cda700a6cca6b04e309718dcc5741e2b9eeca8f59edc9de9c42de7c50d0efd673fdde42adc4b09b0bb70b8b19dda1a4166ca6fba6fd7b3a795a79b8abb6d74bc310cb3a1baf409a88431c8c8c401074dbfc164549123b505242578e75cd4eba64fe9f4df334532949de71bce45af06a7e9bb56a51c5995722ca35db53853d51a534531ba094c6db298f76d608c15c3d9aa2af5526523536f6bf5c67e256d0ea252081f266821ff5fb2e152d568c54ce905559759ed2e70268a0ed11fff41c76a16060d61b5037ffae4f12487805e9da8649b3217d8cd89e499cb711c7bc1894cc36e742247660ab5601a9c282b62bdac13c1ca32f7793d49bdec496a5386ba5b2228a1aa0a35d99add10878b3c8e14254cb99e2e91e6f10c3dcdeb9e27a84367719b21f0759177a380a262c76619fd0f71cab37666176b65d972e94897eb03ac8b639e7beddeab8492b30c557016fc341cc959d2053681f3290c31fa40c2f188e430444df0a78bab8f67ff7b303b9773f70343a8e812733fc009ba0c5c9784e0dfc3ed6b90f5a8b6af0ed67eaf88566ddb694af9e4e826e3ae8d5679df06d1ea798e5a1dbf9e0f4a1ba78545bc9a29f8791915423eb68c861299fe7aefb336819acf57c80cd5b69a2f0d5e8244678576c3ca0b3f1242e526c3508fdbcd572dcfdf64ec9b4d6a2003c025c8d60e90f77df952816a2d41b577b827dadb0d6005e326f5cd592a559f3e35de17b5508990cb0ea09feee3e6a862d0eabc96a9d7d73201946135796d5364587ea2b2ebcd91045bae758a06a3eee648e8b87a73742a6e8ea280f70521132a95559b43177c5d65db0e95545cba3a15b101820b8a62e050dac49fac3856c05882ce201ac1c46156e38ec18168123c90223e5bc090aa74819dc0e92afa807d3832ad03ee00f5807cde01462c74258132340e5326ee0164bc0843b05cec411ff37108fb2757c40884ad08c28abc2d982de058d39a16500d88abc359be92eda2157a53db3d7d9add2e6403df16b06dc3d2cdddf7bd47522e0ea1b5e81085450cc924202147e03592ad60f73f861834750ebb38c99f2255ac04e1d493c19096d11ada521662d66721c60f9f852cd58776ca42be13aff7f6ceebfaff13afeb8bbcaeafc7ebb06de5e288a56e704991bf8a4c0ae5661715778b6ef27afb55527f7beb3a6a71fbd5b6cca5977d966ad5da288cad7bd79703d9fc09ec5cd9cb665afb08bea895eebd9067375dc8ea3ffed38afd51767b6dca1e896c2d0bd922a6ca280b8bf066cbf84c2099e15cd42492a2de2b17b0fcfac05efdfa20b7da5ddf1b146c2edf18ccb8dcaa932846afe725bbbe3730c47f2f2a71b566e5ef0d345dad70b1a3376424af0f0ebe13e52e3c38b074c368b6deba07079bd36e775dbabd7f14de32485992e557f1879fafb4bf3f0c22d7ef47ee6470ee4cf0df6ec67ddde4577723e3e7bb0b3827fd17149b5e5ff6360000\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 27 Jul 2021 17:34:52 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-transform, max-age=300"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "via",
+              "value": "1.1 search.dip.bundestag.de"
+            },
+            {
+              "name": "access-control-allow-headers",
+              "value": "origin, x-requested-with, content-type, authorization, content-disposition, accept"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "OPTIONS,GET,PUT,POST,DELETE,HEAD"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 656,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-07-27T17:34:44.174Z",
+        "time": 99,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 99
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/bundestag.io/dip/package.json
+++ b/bundestag.io/dip/package.json
@@ -21,7 +21,6 @@
     "@types/pollyjs__adapter-node-http": "^2.0.1",
     "@types/pollyjs__persister-fs": "^2.0.1",
     "@types/setup-polly-jest": "^0.5.1",
-    "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.0",
     "eslint": "^7.29.0",
@@ -30,7 +29,6 @@
     "jest": "^27.0.4",
     "prettier": "2.3.1",
     "setup-polly-jest": "^0.9.1",
-    "supertest": "^6.1.3",
     "ts-jest": "^27.0.3",
     "ts-node-dev": "^1.1.6",
     "typescript": "^4.3.2"

--- a/bundestag.io/dip/package.json
+++ b/bundestag.io/dip/package.json
@@ -35,12 +35,15 @@
   },
   "dependencies": {
     "@democracy-deutschland/bt-dip-sdk": "^0.1.0-alpha.8",
+    "@graphql-tools/schema": "^7.1.5",
     "apollo-datasource-rest": "^0.14.0",
     "apollo-server": "^2.25.1",
     "apollo-server-express": "^2.25.1",
     "async-sema": "^3.1.0",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "graphql": "^15.5.0"
+    "graphql": "^15.5.0",
+    "graphql-middleware": "^6.0.10",
+    "striptags": "^4.0.0-alpha.2"
   }
 }

--- a/bundestag.io/dip/src/middlewares/stripHTML.spec.ts
+++ b/bundestag.io/dip/src/middlewares/stripHTML.spec.ts
@@ -1,0 +1,89 @@
+/** @jest-environment setup-polly-jest/jest-environment-node */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import createServer from '../server';
+
+let mockDipAPI: any;
+
+beforeEach(() => {
+  mockDipAPI = {
+    getVorgang: jest.fn(),
+    getVorgangsVorgangspositionen: jest.fn(),
+  };
+});
+
+const DIP_API_KEY = 'WHATEVER';
+const { server } = createServer({
+  DIP_API_KEY,
+  DIP_API_ENDPOINT: 'https://search.dip.bundestag.de',
+  RATE_LIMIT: 20,
+  config: {
+    dataSources: () => ({ dipAPI: mockDipAPI }),
+  },
+});
+
+const gql = String.raw;
+
+describe('middlewares', () => {
+  describe('stripHTML', () => {
+    const query = gql`
+      query ($procedureId: ID!) {
+        procedure(id: $procedureId) {
+          abstract
+          procedureId
+          period
+          date
+          history {
+            abstract
+          }
+        }
+      }
+    `;
+
+    describe('when DipAPI returns some data containing HTML', () => {
+      beforeEach(() => {
+        mockDipAPI.getVorgang.mockResolvedValue({
+          abstract: '<strong>Beschlussempfehlung des Ausschusses: Änderungen</strong>',
+          id: '275942',
+          wahlperiode: 19,
+          datum: '2021-06-25',
+        });
+        mockDipAPI.getVorgangsVorgangspositionen.mockResolvedValue([
+          {
+            abstract: '<p>Some abstract with HTML</p>',
+          },
+        ]);
+      });
+
+      it('removes HTML from Procedure.abstract', async () => {
+        const variables = { procedureId: '275942' };
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
+          data: {
+            procedure: {
+              abstract: 'Beschlussempfehlung des Ausschusses: Änderungen',
+              procedureId: '275942',
+              period: 19,
+              date: '2021-06-25',
+            },
+          },
+          errors: undefined,
+        });
+      });
+
+      it('removes HTML from ProcessFlow.abstract', async () => {
+        const variables = { procedureId: '275942' };
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
+          data: {
+            procedure: {
+              history: [
+                {
+                  abstract: 'Some abstract with HTML',
+                },
+              ],
+            },
+          },
+          errors: undefined,
+        });
+      });
+    });
+  });
+});

--- a/bundestag.io/dip/src/middlewares/stripHTML.ts
+++ b/bundestag.io/dip/src/middlewares/stripHTML.ts
@@ -1,0 +1,17 @@
+import { striptags } from 'striptags';
+import { IMiddlewareFunction } from 'graphql-middleware';
+
+const stripHTML: IMiddlewareFunction = async (resolve, parent, args, context, info) => {
+  const unescaped = await resolve(parent, args, context, info);
+  if (!unescaped) return unescaped;
+  return striptags(unescaped);
+};
+
+export default {
+  ProcessFlow: {
+    abstract: stripHTML,
+  },
+  Procedure: {
+    abstract: stripHTML,
+  },
+};

--- a/bundestag.io/dip/src/server.spec.ts
+++ b/bundestag.io/dip/src/server.spec.ts
@@ -1,6 +1,6 @@
 /** @jest-environment setup-polly-jest/jest-environment-node */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { setupPolly } from 'setup-polly-jest';
-import supertest from 'supertest';
 import createServer from './server';
 import NodeHTTPAdapter from '@pollyjs/adapter-node-http';
 import FSPersister from '@pollyjs/persister-fs';
@@ -19,17 +19,9 @@ const context = setupPolly({
 const randomObjects = (n: number) => Array.from(Array(n).keys()).map(() => expect.any(Object));
 
 const DIP_API_KEY = 'N64VhW8.yChkBUIJeosGojQ7CSR2xwLf3Qy7Apw464';
-const { app } = createServer({ DIP_API_KEY, DIP_API_ENDPOINT: 'https://search.dip.bundestag.de', RATE_LIMIT: 20 });
-
-const request = supertest(app);
+const { server } = createServer({ DIP_API_KEY, DIP_API_ENDPOINT: 'https://search.dip.bundestag.de', RATE_LIMIT: 20 });
 
 const gql = String.raw;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const runQuery = async ({ query, variables }: { query: string; variables?: Record<string, unknown> }): Promise<any> => {
-  const res = await request.post('/').send({ query, variables }).set('Accept', 'application/json').expect(200);
-  return JSON.parse(res.text);
-};
 
 describe('Query', () => {
   beforeEach(() => {
@@ -92,7 +84,7 @@ describe('Query', () => {
 
     it('returns gestOrderNumber', async () => {
       const variables = { procedureId: '275933' };
-      await expect(runQuery({ query, variables })).resolves.toMatchObject({
+      await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
         data: {
           procedure: {
             procedureId: '275933',
@@ -106,7 +98,7 @@ describe('Query', () => {
 
     it('returns legalValidity', async () => {
       const variables = { procedureId: '155381' };
-      await expect(runQuery({ query, variables })).resolves.toMatchObject({
+      await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
         data: {
           procedure: {
             procedureId: '155381',
@@ -122,7 +114,7 @@ describe('Query', () => {
     describe('history', () => {
       it('returns assignment+initiator', async () => {
         const variables = { procedureId: '234344' };
-        await expect(runQuery({ query, variables })).resolves.toMatchObject({
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
           data: {
             procedure: {
               procedureId: '234344',
@@ -146,7 +138,7 @@ describe('Query', () => {
 
       it('returns findSpot+findSpotUrl', async () => {
         const variables = { procedureId: '234344' };
-        await expect(runQuery({ query, variables })).resolves.toMatchObject({
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
           data: {
             procedure: {
               procedureId: '234344',
@@ -179,7 +171,7 @@ describe('Query', () => {
 
       it('returns date', async () => {
         const variables = { procedureId: '234344' };
-        await expect(runQuery({ query, variables })).resolves.toMatchObject({
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
           data: {
             procedure: {
               procedureId: '234344',
@@ -198,7 +190,7 @@ describe('Query', () => {
       describe('decision', () => {
         it('returns page+tenor+document+type+comment', async () => {
           const variables = { procedureId: '234344' };
-          await expect(runQuery({ query, variables })).resolves.toMatchObject({
+          await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
             data: {
               procedure: {
                 procedureId: '234344',
@@ -234,7 +226,7 @@ describe('Query', () => {
 
         it('returns foundation', async () => {
           const variables = { procedureId: '233294' };
-          await expect(runQuery({ query, variables })).resolves.toMatchObject({
+          await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
             data: {
               procedure: {
                 procedureId: '233294',
@@ -260,7 +252,7 @@ describe('Query', () => {
 
         it('returns majority', async () => {
           const variables = { procedureId: '44236' };
-          await expect(runQuery({ query, variables })).resolves.toMatchObject({
+          await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
             data: {
               procedure: {
                 procedureId: '44236',
@@ -328,7 +320,7 @@ describe('Query', () => {
             data: {
               procedures: { edges },
             },
-          } = await runQuery({ query, variables });
+          }: any = await server.executeOperation({ query, variables });
           expect(edges).toHaveLength(17);
         });
       });
@@ -342,7 +334,7 @@ describe('Query', () => {
             data: {
               procedures: { edges },
             },
-          } = await runQuery({ query, variables });
+          }: any = await server.executeOperation({ query, variables });
           expect(edges).toHaveLength(50);
           expect(edges).toMatchObject([
             expect.objectContaining({ node: { procedureId: '279259' } }),
@@ -354,7 +346,7 @@ describe('Query', () => {
 
         it('limit must be divisible of 50', async () => {
           const variables = { limit: 3 };
-          await expect(runQuery({ query, variables })).resolves.toMatchObject({
+          await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
             data: { procedures: null },
             errors: [
               expect.objectContaining({
@@ -372,7 +364,7 @@ describe('Query', () => {
               data: {
                 procedures: { edges },
               },
-            } = await runQuery({ query, variables });
+            }: any = await server.executeOperation({ query, variables });
             const idSet = new Set(edges.map((edge: { node: { procedureId: number } }) => edge.node.procedureId));
             expect(edges).toHaveLength(100);
             expect(idSet.size).toEqual(100);
@@ -384,7 +376,7 @@ describe('Query', () => {
               data: {
                 procedures: { edges },
               },
-            } = await runQuery({ query, variables });
+            }: any = await server.executeOperation({ query, variables });
             const idSet = new Set(edges.map((edge: { node: { procedureId: number } }) => edge.node.procedureId));
             expect(edges).toHaveLength(2);
             expect(idSet.size).toEqual(2);
@@ -398,7 +390,7 @@ describe('Query', () => {
             data: {
               procedures: { edges },
             },
-          } = await runQuery({
+          }: any = await server.executeOperation({
             query,
             variables: {
               filter: { after: '2021-06-14', before: '2021-06-18' },
@@ -417,14 +409,14 @@ describe('Query', () => {
             data: {
               procedures: { edges },
             },
-          } = await runQuery({
+          } = (await server.executeOperation({
             query,
             variables: {
               filter: { after: '2021-06-14', before: '2021-06-18' },
               offset: 2,
               limit: 50,
             },
-          }));
+          })) as any);
           expect(edges).toHaveLength(50);
           expect(edges).toMatchObject([
             expect.objectContaining({ node: { procedureId: '279257' } }),
@@ -442,7 +434,7 @@ describe('Query', () => {
             data: {
               procedures: { edges },
             },
-          } = await runQuery({ query, variables });
+          }: any = await server.executeOperation({ query, variables });
           expect(edges).toHaveLength(50);
           expect(edges).toMatchObject([
             expect.objectContaining({ node: { procedureId: '277500' } }),
@@ -457,7 +449,7 @@ describe('Query', () => {
     describe('pageInfo', () => {
       it('maps to numFound', async () => {
         const variables = { before: '2021-06-18' };
-        await expect(runQuery({ query, variables })).resolves.toMatchObject({
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
           data: {
             procedures: {
               totalCount: 277499,
@@ -468,7 +460,7 @@ describe('Query', () => {
 
       it('hasNextPage indicates if there are more entries', async () => {
         const variables = { filter: { before: '1970-01-01' } };
-        await expect(runQuery({ query, variables })).resolves.toMatchObject({
+        await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
           data: {
             procedures: {
               pageInfo: {

--- a/bundestag.io/dip/src/server.spec.ts
+++ b/bundestag.io/dip/src/server.spec.ts
@@ -111,6 +111,20 @@ describe('Query', () => {
       });
     });
 
+    it('removes HTML from `abstract`', async () => {
+      const variables = { procedureId: '275942' };
+      await expect(server.executeOperation({ query, variables })).resolves.toMatchObject({
+        data: {
+          procedure: {
+            abstract: 'Beschlussempfehlung des Ausschusses: Änderungen',
+            procedureId: '275942',
+            period: 19,
+            date: '2021-06-25',
+          },
+        },
+      });
+    });
+
     describe('history', () => {
       it('returns assignment+initiator', async () => {
         const variables = { procedureId: '234344' };

--- a/bundestag.io/dip/src/server.ts
+++ b/bundestag.io/dip/src/server.ts
@@ -1,23 +1,31 @@
 import express from 'express';
-import { ApolloServer } from 'apollo-server-express';
+import { ApolloServer, ApolloServerExpressConfig } from 'apollo-server-express';
+import { makeExecutableSchema } from '@graphql-tools/schema';
 import DipAPI from './DipAPI';
 import typeDefs from './schema';
 import resolvers from './resolvers';
+import stripHTML from './middlewares/stripHTML';
+import { applyMiddleware } from 'graphql-middleware';
+
+const middlewares = [stripHTML];
 
 export default function createServer({
   DIP_API_ENDPOINT,
   DIP_API_KEY,
   RATE_LIMIT,
+  config,
 }: {
   DIP_API_ENDPOINT: string;
   DIP_API_KEY: string;
   RATE_LIMIT: number;
+  config?: ApolloServerExpressConfig;
 }): { app: express.Express; server: ApolloServer } {
+  const schema = applyMiddleware(makeExecutableSchema({ typeDefs, resolvers }), ...middlewares);
   const server = new ApolloServer({
-    typeDefs,
-    resolvers,
+    schema,
     dataSources: () => ({ dipAPI: new DipAPI({ baseURL: DIP_API_ENDPOINT, limit: RATE_LIMIT }) }),
     context: () => ({ DIP_API_KEY }),
+    ...config,
   });
   const app = express();
   server.applyMiddleware({ app, path: '/' });

--- a/bundestag.io/dip/yarn.lock
+++ b/bundestag.io/dip/yarn.lock
@@ -805,11 +805,6 @@
   resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.3.tgz#0aa116701955c2faa0717fc69cd1596095e49d96"
   integrity sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg==
 
-"@types/cookiejar@*":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
-  integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
-
 "@types/cookies@*":
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.6.tgz#71212c5391a976d3bae57d4b09fac20fc6bda504"
@@ -1043,21 +1038,6 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
-
-"@types/superagent@*":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.11.tgz#4822bc64a82a0f579261a77097dbca276556c20e"
-  integrity sha512-cZkWBXZI+jESnUTp8RDGBmk1Zn2MkScP4V5bjD7DyqB7L0WNWpblh4KX5K/6aTqxFZMhfo1bhi2cwoAEDVBBJw==
-  dependencies:
-    "@types/cookiejar" "*"
-    "@types/node" "*"
-
-"@types/supertest@^2.0.11":
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-2.0.11.tgz#2e70f69f220bc77b4f660d72c2e1a4231f44a77d"
-  integrity sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==
-  dependencies:
-    "@types/superagent" "*"
 
 "@types/ws@^7.0.0":
   version "7.4.4"
@@ -1894,11 +1874,6 @@ commander@^2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-component-emitter@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1932,11 +1907,6 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
-
-cookiejar@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
-  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 core-js-pure@^3.10.2:
   version "3.14.0"
@@ -2486,11 +2456,6 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-safe-stringify@^2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
-  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
-
 fastq@^1.6.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.0.tgz#bb9fb955a07130a918eb63c1f5161cc32a5d0858"
@@ -2576,11 +2541,6 @@ form-data@^3.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
-
-formidable@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
-  integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -2911,7 +2871,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3780,7 +3740,7 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@^1.1.2, methods@~1.1.2:
+methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -3809,11 +3769,6 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-
-mime@^2.4.6:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
-  integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -4230,7 +4185,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.7.0, qs@^6.9.4:
+qs@^6.7.0:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
@@ -4283,15 +4238,6 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
-
-readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
 
 readdirp@~3.5.0:
   version "3.5.0"
@@ -4401,7 +4347,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -4651,13 +4597,6 @@ string.prototype.trimstart@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 strip-ansi@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
@@ -4714,31 +4653,6 @@ subscriptions-transport-ws@^0.9.19:
     iterall "^1.2.1"
     symbol-observable "^1.0.4"
     ws "^5.2.0 || ^6.0.0 || ^7.0.0"
-
-superagent@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-6.1.0.tgz#09f08807bc41108ef164cfb4be293cebd480f4a6"
-  integrity sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==
-  dependencies:
-    component-emitter "^1.3.0"
-    cookiejar "^2.1.2"
-    debug "^4.1.1"
-    fast-safe-stringify "^2.0.7"
-    form-data "^3.0.0"
-    formidable "^1.2.2"
-    methods "^1.1.2"
-    mime "^2.4.6"
-    qs "^6.9.4"
-    readable-stream "^3.6.0"
-    semver "^7.3.2"
-
-supertest@^6.1.3:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.1.3.tgz#3f49ea964514c206c334073e8dc4e70519c7403f"
-  integrity sha512-v2NVRyP73XDewKb65adz+yug1XMtmvij63qIWHZzSX8tp6wiq6xBLUy4SUAd2NII6wIipOmHT/FD9eicpJwdgQ==
-  dependencies:
-    methods "^1.1.2"
-    superagent "^6.1.0"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -5033,11 +4947,6 @@ utf8-byte-length@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
   integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
-
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util.promisify@^1.0.0:
   version "1.1.1"

--- a/bundestag.io/dip/yarn.lock
+++ b/bundestag.io/dip/yarn.lock
@@ -46,6 +46,13 @@
     http-errors "^1.7.3"
     object-path "^0.11.4"
 
+"@ardatan/aggregate-error@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz#fe6924771ea40fc98dc7a7045c2e872dc8527609"
+  integrity sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==
+  dependencies:
+    tslib "~2.0.1"
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -372,6 +379,47 @@
     js-yaml "^3.13.1"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
+
+"@graphql-tools/batch-execute@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-7.1.2.tgz#35ba09a1e0f80f34f1ce111d23c40f039d4403a0"
+  integrity sha512-IuR2SB2MnC2ztA/XeTMTfWcA0Wy7ZH5u+nDkDNLAdX+AaSyDnsQS35sCmHqG0VOGTl7rzoyBWLCKGwSJplgtwg==
+  dependencies:
+    "@graphql-tools/utils" "^7.7.0"
+    dataloader "2.0.0"
+    tslib "~2.2.0"
+    value-or-promise "1.0.6"
+
+"@graphql-tools/delegate@^7.1.5":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-7.1.5.tgz#0b027819b7047eff29bacbd5032e34a3d64bd093"
+  integrity sha512-bQu+hDd37e+FZ0CQGEEczmRSfQRnnXeUxI/0miDV+NV/zCbEdIJj5tYFNrKT03W6wgdqx8U06d8L23LxvGri/g==
+  dependencies:
+    "@ardatan/aggregate-error" "0.0.6"
+    "@graphql-tools/batch-execute" "^7.1.2"
+    "@graphql-tools/schema" "^7.1.5"
+    "@graphql-tools/utils" "^7.7.1"
+    dataloader "2.0.0"
+    tslib "~2.2.0"
+    value-or-promise "1.0.6"
+
+"@graphql-tools/schema@^7.1.5":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-7.1.5.tgz#07b24e52b182e736a6b77c829fc48b84d89aa711"
+  integrity sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==
+  dependencies:
+    "@graphql-tools/utils" "^7.1.2"
+    tslib "~2.2.0"
+    value-or-promise "1.0.6"
+
+"@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.7.0", "@graphql-tools/utils@^7.7.1":
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.10.0.tgz#07a4cb5d1bec1ff1dc1d47a935919ee6abd38699"
+  integrity sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==
+  dependencies:
+    "@ardatan/aggregate-error" "0.0.6"
+    camel-case "4.1.2"
+    tslib "~2.2.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1739,6 +1787,14 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camel-case@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
+  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
+  dependencies:
+    pascal-case "^3.1.2"
+    tslib "^2.0.3"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -1972,6 +2028,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+dataloader@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
+  integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
 
 dateformat@~1.0.4-1.2.3:
   version "1.0.12"
@@ -2676,6 +2737,14 @@ graphql-extensions@^0.15.0:
     "@apollographql/apollo-tools" "^0.5.0"
     apollo-server-env "^3.1.0"
     apollo-server-types "^0.9.0"
+
+graphql-middleware@^6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/graphql-middleware/-/graphql-middleware-6.0.10.tgz#b4ff68da95b8fbed7b4f98ec43c5cf19ed0e46c5"
+  integrity sha512-RKW1vbgaFLgU5i1sjdL4ClZVI0C67u+DsuG5jZ0YzREduGCsmIvXiB0ffjwOvMbQKTVPZjZWUlhIdP/DK3zxLw==
+  dependencies:
+    "@graphql-tools/delegate" "^7.1.5"
+    "@graphql-tools/schema" "^7.1.5"
 
 graphql-subscriptions@^1.0.0:
   version "1.2.1"
@@ -3673,6 +3742,13 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -3827,6 +3903,14 @@ negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 nocache@^2.1.0:
   version "2.1.0"
@@ -4026,6 +4110,14 @@ parseurl@^1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+pascal-case@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
+  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -4643,6 +4735,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+striptags@^4.0.0-alpha.2:
+  version "4.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/striptags/-/striptags-4.0.0-alpha.2.tgz#e911eb286a3ca5d0c1d53a8449a1a9e933b1305c"
+  integrity sha512-KM2d9idEHtI4961q0UC67uIoNAuRpKh4Asjkjhw/QzXPwQlgEOcmBuP+pw2fTZpqnL2VYc7wUX0xJN/zKvXwWQ==
+
 subscriptions-transport-ws@^0.9.19:
   version "0.9.19"
   resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz#10ca32f7e291d5ee8eb728b9c02e43c52606cdcf"
@@ -4847,10 +4944,20 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0:
+tslib@^2.0.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^2.1.0, tslib@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
+tslib@~2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -4995,6 +5102,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-or-promise@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.6.tgz#218aa4794aa2ee24dcf48a29aba4413ed584747f"
+  integrity sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This includes an integration test calling the actual DIP endpoint
(therefore the recording) plus a unit test with a mocked DipAPI.

I've used `graphql-middleware` to plug-in `striptags` into the resolver
map. I could see that the package has been used elsewhere, so I thought
it wouldn't hurt to add it as a dependency.

I couldn't find a procedure which has HTML in the `abstract` of its
`history` entries. Therefore I simulated the behaviour in a unit test.
@ManAnRuck feel free to add `striptags` to more attributes.


### Issues

fix #462


### Checklist

- [x] None

### Repositories Affected

<!-- Did you update any Submodules? -->

- [ ] bundestag.io
- [ ] bundestag.io-admin
- [ ] client
- [ ] democracy-app.de
- [ ] democracy-app.de-api
- [ ] democracy-deutschland.de
- [ ] docu
- [ ] elasticsearch
- [x] bundestag-io/dip

### How2Test
```
yarn run test
```

For real: Procedure with id `275942` contained HTML in its `abstract`.
