### PR TITLE
Create GraphQL endpoint for parties by legislature period

### DIFF
--- a/bundestag.io/api/src/graphql/resolvers/Procedure.ts
+++ b/bundestag.io/api/src/graphql/resolvers/Procedure.ts
@@ -505,6 +505,22 @@ const ProcedureResolvers: Resolvers = {
         { $match: { 'session.top.topic.procedureId': procedure.procedureId } },
       ]),
   },
+
+  LegislativePeriod: {
+    parties: async (legislativePeriod, _, { DeputyModel }) => {
+      const deputies = await DeputyModel.find({ period: legislativePeriod.number });
+      const parties = deputies.reduce((acc, deputy) => {
+        const party = acc.find((p) => p.name === deputy.party);
+        if (party) {
+          party.deputies.push(deputy);
+        } else {
+          acc.push({ name: deputy.party, deputies: [deputy] });
+        }
+        return acc;
+      }, []);
+      return parties;
+    },
+  },
 };
 
 export default ProcedureResolvers;

--- a/bundestag.io/api/src/graphql/resolvers/index.ts
+++ b/bundestag.io/api/src/graphql/resolvers/index.ts
@@ -5,4 +5,22 @@ import NamedPoll from './NamedPoll';
 import Procedure from './Procedure';
 import _ from 'lodash';
 
-export default _.merge({}, ConferenceWeekDetail, Date, Deputy, NamedPoll, Procedure);
+const LegislativePeriod = {
+  LegislativePeriod: {
+    parties: async (legislativePeriod, _, { DeputyModel }) => {
+      const deputies = await DeputyModel.find({ period: legislativePeriod.number });
+      const parties = deputies.reduce((acc, deputy) => {
+        const party = acc.find((p) => p.name === deputy.party);
+        if (party) {
+          party.deputies.push(deputy);
+        } else {
+          acc.push({ name: deputy.party, deputies: [deputy] });
+        }
+        return acc;
+      }, []);
+      return parties;
+    },
+  },
+};
+
+export default _.merge({}, ConferenceWeekDetail, Date, Deputy, NamedPoll, Procedure, LegislativePeriod);

--- a/bundestag.io/api/src/graphql/resolvers/types.ts
+++ b/bundestag.io/api/src/graphql/resolvers/types.ts
@@ -244,6 +244,13 @@ export type LegislativePeriod = {
   start: Scalars['Date'];
   end?: Maybe<Scalars['Date']>;
   deputies: Scalars['Int'];
+  parties?: Maybe<Array<Maybe<Party>>>;
+};
+
+export type Party = {
+  __typename?: 'Party';
+  name: Scalars['String'];
+  deputies?: Maybe<Array<Maybe<Deputy>>>;
 };
 
 export type NamedPollMediaVideoUrl = {
@@ -1010,6 +1017,16 @@ export type LegislativePeriodResolvers<
   start?: Resolver<ResolversTypes['Date'], ParentType, ContextType>;
   end?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
   deputies?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  parties?: Resolver<Maybe<Array<Maybe<ResolversTypes['Party']>>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type PartyResolvers<
+  ContextType = GraphQlContext,
+  ParentType extends ResolversParentTypes['Party'] = ResolversParentTypes['Party'],
+> = {
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  deputies?: Resolver<Maybe<Array<Maybe<ResolversTypes['Deputy']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 
@@ -1428,6 +1445,7 @@ export type Resolvers<ContextType = GraphQlContext> = {
   DeputyUpdate?: DeputyUpdateResolvers<ContextType>;
   Document?: DocumentResolvers<ContextType>;
   LegislativePeriod?: LegislativePeriodResolvers<ContextType>;
+  Party?: PartyResolvers<ContextType>;
   NamedPollMediaVideoURL?: NamedPollMediaVideoUrlResolvers<ContextType>;
   NamedPollMedia?: NamedPollMediaResolvers<ContextType>;
   NamedPollSpeech?: NamedPollSpeechResolvers<ContextType>;

--- a/bundestag.io/api/src/graphql/schemas/Deputy.graphql
+++ b/bundestag.io/api/src/graphql/schemas/Deputy.graphql
@@ -27,6 +27,7 @@ type Deputy {
   speechesURL: String
   votesURL: String
   publicationRequirement: [String]
+  party: Party
 }
 
 type DeputyUpdate {

--- a/bundestag.io/api/src/graphql/schemas/LegislativePeriod.graphql
+++ b/bundestag.io/api/src/graphql/schemas/LegislativePeriod.graphql
@@ -3,6 +3,12 @@ type LegislativePeriod {
   start: Date!
   end: Date
   deputies: Int!
+  parties: [Party]
+}
+
+type Party {
+  name: String!
+  deputies: [Deputy]
 }
 
 type Query {

--- a/bundestag.io/api/src/graphql/schemas/Procedure.graphql
+++ b/bundestag.io/api/src/graphql/schemas/Procedure.graphql
@@ -160,6 +160,7 @@ type Query {
     voteDate: [Boolean!]
     manageVoteDate: Boolean
   ): ProceduresData!
+  partiesByLegislaturePeriod(period: Int!): [Party]
 }
 
 type Mutation {


### PR DESCRIPTION
Add GraphQL endpoint to return all parties selected by a legislature period.

* **Schema Changes:**
  - Add `parties` field to `LegislativePeriod` type in `bundestag.io/api/src/graphql/schemas/LegislativePeriod.graphql`.
  - Define `Party` type with fields `name` and `deputies` in `bundestag.io/api/src/graphql/schemas/LegislativePeriod.graphql`.
  - Add query to fetch parties by legislature period in `bundestag.io/api/src/graphql/schemas/Procedure.graphql`.
  - Add `party` field to `Deputy` type in `bundestag.io/api/src/graphql/schemas/Deputy.graphql`.

* **Resolver Changes:**
  - Add resolver for `parties` field in `LegislativePeriod` type in `bundestag.io/api/src/graphql/resolvers/Procedure.ts`.
  - Merge `LegislativePeriod` resolver with existing resolvers in `bundestag.io/api/src/graphql/resolvers/index.ts`.

* **Type Definitions:**
  - Add type definitions for `Party` and `LegislativePeriod.parties` in `bundestag.io/api/src/graphql/resolvers/types.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/demokratie-live/democracy-development/pull/617?shareId=7fae2222-6322-4b40-a58a-e989366e77d3).