### PR TITLE
fix: update party order in AI votes sorting

### DIFF
--- a/bundestag.io/admin/src/app/layout.tsx
+++ b/bundestag.io/admin/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import 'antd/dist/reset.css';
 import { Navigation } from '@/components/Navigation';
 import { Layout as AntLayout, Breadcrumb } from 'antd';
 

--- a/bundestag.io/admin/src/components/Procedures/AiVotes.tsx
+++ b/bundestag.io/admin/src/components/Procedures/AiVotes.tsx
@@ -1,6 +1,7 @@
 import { Maybe, Vote, VoteResult } from '@/__generated/gql-ai/graphql';
 import { Button, Spin } from 'antd';
 import { useState } from 'react';
+import { getFractions } from './VoteResultsForm';
 
 export type AiVotesProps = {
   decision: string;
@@ -37,14 +38,14 @@ export const AiVotes: React.FC<AiVotesProps> = ({ decision, period, onResult }) 
       }).then((data) => data.json());
 
       response.sort((a, b) => {
-        const partiesOrder = ['Union', 'SPD', 'AfD', 'Grüne', 'FDP', 'Linke'];
+        const partiesOrder = getFractions(period).map((party) => party.name);
         return partiesOrder.indexOf(a.name) - partiesOrder.indexOf(b.name);
       });
 
       setVotes(response);
       onResult?.(response);
     } catch (error) {
-      console.error(error);
+      console.error('Error fetching votes:', error);
     } finally {
       setLoading(false);
     }

--- a/bundestag.io/admin/src/components/Procedures/VoteResultsForm.tsx
+++ b/bundestag.io/admin/src/components/Procedures/VoteResultsForm.tsx
@@ -7,26 +7,45 @@ import { Beschlusstext } from './Beschlusstext';
 // Ant Design Sub-Elements
 const FormItem = Form.Item;
 
-const FRACTIONS = [
-  {
-    name: 'Union',
-  },
-  {
-    name: 'SPD',
-  },
-  {
-    name: 'AfD',
-  },
-  {
-    name: 'Grüne',
-  },
-  {
-    name: 'FDP',
-  },
-  {
-    name: 'Linke',
-  },
-];
+export const getFractions = (period: number) =>
+  period === 21
+    ? [
+        {
+          name: 'Union',
+        },
+        {
+          name: 'AfD',
+        },
+        {
+          name: 'SPD',
+        },
+        {
+          name: 'Grüne',
+        },
+        {
+          name: 'Linke',
+        },
+      ]
+    : [
+        {
+          name: 'Union',
+        },
+        {
+          name: 'SPD',
+        },
+        {
+          name: 'AfD',
+        },
+        {
+          name: 'Grüne',
+        },
+        {
+          name: 'FDP',
+        },
+        {
+          name: 'Linke',
+        },
+      ];
 
 const VoteResultsForm = ({ data, type, procedureId, period, lastPlenaryProtocoll, title }) => {
   const [form] = Form.useForm();
@@ -80,7 +99,7 @@ const VoteResultsForm = ({ data, type, procedureId, period, lastPlenaryProtocoll
     });
   };
 
-  let parties = FRACTIONS;
+  let parties = getFractions(period);
   if (data.partyVotes && data.partyVotes.length > 0) {
     parties = data.partyVotes.map(({ party }) => ({
       name: party,


### PR DESCRIPTION
This pull request includes changes to the `bundestag.io/admin/src/components/Procedures` directory to update the handling of party fractions based on the legislative period. The most important changes include modifying the sorting order of parties and dynamically generating the list of parties based on the period.

Updates to party handling:

* [`bundestag.io/admin/src/components/Procedures/AiVotes.tsx`](diffhunk://#diff-b10aafcb9e3a0dd4d6dda87246b3207aabd43f450dbb95c4e1e96ca9d76d51f6L40-R40): Modified the `partiesOrder` array to remove 'FDP' from the sorting order.
* [`bundestag.io/admin/src/components/Procedures/VoteResultsForm.tsx`](diffhunk://#diff-c6769766699826388fb0f433962b35b1dbff2294268c5845e9c515ff39123eacL10-R29): Replaced the static `FRACTIONS` array with the `getFractions` function to dynamically generate the list of parties based on the legislative period.
* [`bundestag.io/admin/src/components/Procedures/VoteResultsForm.tsx`](diffhunk://#diff-c6769766699826388fb0f433962b35b1dbff2294268c5845e9c515ff39123eacL83-R102): Updated the `parties` variable to use the `getFractions` function instead of the static `FRACTIONS` array.