### PR TITLE
feat: sync procedures of period 21

### DIFF
--- a/services/cron-jobs/sync-procedures/src/index.ts
+++ b/services/cron-jobs/sync-procedures/src/index.ts
@@ -254,7 +254,7 @@ const start = async () => {
         since,
         limit,
         offset,
-        periods: [18, 19, 20],
+        periods: [18, 19, 20, 21],
         types: [PROCEDURE_DEFINITIONS.TYPE.GESETZGEBUNG, PROCEDURE_DEFINITIONS.TYPE.ANTRAG],
       };
       const {


### PR DESCRIPTION
This pull request makes a small adjustment to the `services/cron-jobs/sync-procedures/src/index.ts` file. The change adds a new period (`21`) to the `periods` array in the `start` function configuration.