### PR TITLE
Feature/sync procedure 21

### DIFF
--- a/democracy/desktop/src/config/constants.ts
+++ b/democracy/desktop/src/config/constants.ts
@@ -1,3 +1,3 @@
 export const config = {
-  period: 20,
+  period: 21,
 };

--- a/services/cron-jobs/import-plenary-minutes/src/index.ts
+++ b/services/cron-jobs/import-plenary-minutes/src/index.ts
@@ -77,6 +77,7 @@ const getUrl = ({ offset, id }: { offset: number; id: string }) =>
 const periods = [
   { period: 19, id: '543410-543410' },
   { period: 20, id: '866354-866354' },
+  { period: 21, id: '1058442-1058442' },
 ];
 
 const start = async (period: number) => {


### PR DESCRIPTION
This pull request updates various parts of the codebase to include support for a new legislative period, `period: 21`. The changes ensure that the new period is reflected in configuration files and service logic.

### Updates for new legislative period:

* [`democracy/desktop/src/config/constants.ts`](diffhunk://#diff-bed05e8c8c9058d6c9e27861899ce2a4a481b66213bade9f8ad035bc017382b7L2-R2): Updated the `period` value in the configuration from `20` to `21`.
* [`services/cron-jobs/import-plenary-minutes/src/index.ts`](diffhunk://#diff-c5aaea2dc6104988b8ae47c05e0070317e8d7ddac84f7f1e72848686d9c59576R80): Added `period: 21` with its corresponding ID to the `periods` array in the `getUrl` function.
* [`services/cron-jobs/sync-procedures/src/index.ts`](diffhunk://#diff-8ffd47a9c3d09d3d959e5e61128b4fc7b551591f9cd129a41d8b7e844f05a637L257-R257): Included `period: 21` in the `periods` array in the `start` function to ensure synchronization covers the new period.