### PR TITLE
feat: rename deployment and update configuration for import-plenary-m…

### DIFF
--- a/services/cron-jobs/import-plenary-minutes/garden.yml
+++ b/services/cron-jobs/import-plenary-minutes/garden.yml
@@ -17,29 +17,37 @@ spec:
 
 ---
 kind: Deploy
-name: import-plenary-minutes
+name: import-plenary-minutes-config
 type: kubernetes
-description: Deploy the importer of procedures for the bundestag.io API
-dependencies: [build.import-plenary-minutes, deploy.mongo]
-
-disabled: ${!(environment.name == "prod" || environment.name == "local-prod")}
 
 variables:
   DB_URL: mongodb://democracy-mongo:27017/bundestagio
 
+source:
+  path: manifests
+
 spec:
   manifestTemplates:
-    - ./manifests/*
+    - ConfigMap.yaml
 
-  patchResources:
-    - name: import-plenary-minutes
-      kind: CronJob
-      patch:
-        spec:
-          jobTemplate:
-            spec:
-              template:
-                spec:
-                  containers:
-                    - name: import-plenary-minutes
-                      image: ${actions.build.import-plenary-minutes.outputs.deploymentImageId}
+---
+kind: Run
+name: import-plenary-minutes
+description: Ad-hoc Import-Job für Plenarprotokolle
+dependencies:
+  - build.import-plenary-minutes
+  - deploy.mongo
+  - deploy.import-plenary-minutes-config
+
+type: kubernetes-pod
+
+spec:
+  podSpec:
+    restartPolicy: Never
+    containers:
+      - name: import-plenary-minutes
+        image: ${actions.build.import-plenary-minutes.outputs.deploymentImageId}
+        imagePullPolicy: IfNotPresent
+        envFrom:
+          - configMapRef:
+              name: import-plenary-minutes

--- a/services/cron-jobs/import-plenary-minutes/src/index.ts
+++ b/services/cron-jobs/import-plenary-minutes/src/index.ts
@@ -82,6 +82,7 @@ const periods = [
 
 const start = async (period: number) => {
   const periodId = periods.find((p) => p.period === period)!.id;
+  console.log('start import for period', period);
 
   let url: string | false = getUrl({ offset: 0, id: periodId });
   const data: PlenaryMinutesItem[] = [];
@@ -116,7 +117,8 @@ const start = async (period: number) => {
   }
   await mongoConnect(process.env.DB_URL);
   console.log('PlenaryMinutes', await PlenaryMinuteModel.countDocuments({}));
-  await start(19);
-  await start(20);
+  for (const period of periods) {
+    await start(period.period);
+  }
   process.exit(0);
 })();


### PR DESCRIPTION
This pull request restructures the deployment configuration for the plenary minutes import job and improves the import script for better maintainability and clarity. The most important changes are grouped below:

**Deployment Configuration Refactor:**

* Split the `garden.yml` deployment into two separate resources: a `ConfigMap` deploy (`import-plenary-minutes-config`) and an ad-hoc import job (`import-plenary-minutes`), improving separation of concerns and maintainability.
* Updated the import job to use environment variables from a `ConfigMap` and set the container `imagePullPolicy` to `IfNotPresent`, ensuring correct configuration and more efficient image usage.

**Import Script Improvements:**

* Enhanced logging by adding a message indicating which period is being imported, making the import process more transparent.
* Refactored the import logic to iterate over all periods in the `periods` array instead of calling `start` for each period explicitly, making the code more scalable and easier to maintain.
fixes #680