### PR TITLE
chore(garden): improve garden configs

### DIFF
--- a/democracy/desktop/garden.yml
+++ b/democracy/desktop/garden.yml
@@ -52,3 +52,8 @@ spec:
               containers:
                 - name: democracy-desktop
                   image: ${actions.build.democracy-desktop.outputs.deploymentImageId}
+                  env:
+                    - name: APP_HOST
+                      value: http://democracy-api
+                    - name: APP_API_URL
+                      value: http://democracy-api

--- a/services/cron-jobs/crawler/garden.yml
+++ b/services/cron-jobs/crawler/garden.yml
@@ -1,23 +1,3 @@
-kind: Deploy
-name: crawler-config
-type: kubernetes
-
-varfiles:
-  - .env
-  - .env.local
-
-variables:
-  DB_URL: mongodb://democracy-mongo:27017/bundestagio
-
-source:
-  path: manifests # Manifeste liegen hier außerhalb des Action‑Verzeichnisses
-
-spec:
-  manifestTemplates:
-    - configmap.yaml # ---> infra/manifests/configmap.yaml wird angewendet
-    - secret.yaml
-
----
 kind: Build
 name: import-procedures
 description: Import procedures for the bundestag.io API
@@ -36,20 +16,21 @@ spec:
   extraFlags: ['--load']
 
 ---
-# 2) Run-Aktion: Ad-hoc Kubernetes-Pod für einmalige Imports
-#    Sync wird hier nicht unterstützt. Für Hot-Reload und Entwicklungsmodus siehe Deploy-Aktion.
 kind: Run
 name: import-procedures
-description: Ad-hoc Import-Job für Prozeduren
-# Abhängigkeit zu Mongo-Deploy beibehalten, damit die DB verfügbar ist
+description: Ad-hoc import-Job for Prozeduren
 dependencies:
   - build.import-procedures
   - deploy.mongo
-  - deploy.crawler-config
 
 varfiles:
-  - .env
-  - .env.local
+  - path: .env
+    optional: true
+  - path: .env.local
+    optional: true
+
+variables:
+  DB_URL: mongodb://democracy-mongo:27017/bundestagio
 
 type: kubernetes-pod
 spec:
@@ -59,10 +40,23 @@ spec:
       - name: import-procedures
         image: ${actions.build.import-procedures.outputs.deploymentImageId}
         imagePullPolicy: IfNotPresent
-        envFrom:
-          - configMapRef:
-              name: crawler-config
-          - secretRef:
-              name: dip-api-token
-# Optional: TTL für automatische Aufräumung (wenn unterstützt)
-#    ttlSecondsAfterFinished: 300
+        env:
+          - name: DB_URL
+            value: ${var.DB_URL}
+          - name: DIP_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: dip-api-token
+                key: DIP_API_KEY
+          - name: DEBUG
+            value: '${var.DEBUG || "false"}'
+          - name: IMPORT_PROCEDURES_CHUNK_ROUNDS
+            value: '${var.IMPORT_PROCEDURES_CHUNK_ROUNDS || "5"}'
+          - name: IMPORT_PROCEDURES_CHUNK_SIZE
+            value: '${var.IMPORT_PROCEDURES_CHUNK_SIZE || "100"}'
+          - name: IMPORT_PROCEDURES_FILTER_AFTER
+            value: '${var.IMPORT_PROCEDURES_FILTER_AFTER || ""}'
+          - name: IMPORT_PROCEDURES_FILTER_TYPES
+            value: '${var.IMPORT_PROCEDURES_FILTER_TYPES || ""}'
+          - name: IMPORT_PROCEDURES_START_CURSOR
+            value: '${var.IMPORT_PROCEDURES_START_CURSOR || "*"}'

--- a/services/cron-jobs/import-conference-week-details/garden.yml
+++ b/services/cron-jobs/import-conference-week-details/garden.yml
@@ -1,0 +1,47 @@
+kind: Build
+name: import-conference-week-details
+description: Import conference week details for the bundestag.io API
+type: container
+source:
+  path: ../../../
+include:
+  - ./**/*
+  - ./infra/Dockerfile
+spec:
+  dockerfile: ./infra/Dockerfile
+  buildArgs:
+    NODE_VERSION: 18.18.2
+    SERVICE: import-conference-week-details
+    SERVICE_PATH: services/cron-jobs/import-conference-week-details
+  extraFlags: ['--load']
+
+---
+kind: Run
+name: import-conference-week-details
+description: Ad-hoc import-Job for Conference Week Details
+dependencies:
+  - build.import-conference-week-details
+  - deploy.mongo
+
+varfiles:
+  - path: .env
+    optional: true
+  - path: .env.local
+    optional: true
+
+variables:
+  DB_URL: mongodb://democracy-mongo:27017/bundestagio
+
+type: kubernetes-pod
+spec:
+  podSpec:
+    restartPolicy: Never
+    containers:
+      - name: import-conference-week-details
+        image: ${actions.build.import-conference-week-details.outputs.deploymentImageId}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: DB_URL
+            value: ${var.DB_URL}
+          - name: DEBUG
+            value: '${var.DEBUG || "false"}'

--- a/services/cron-jobs/import-plenary-minutes/garden.yml
+++ b/services/cron-jobs/import-plenary-minutes/garden.yml
@@ -33,7 +33,7 @@ spec:
 ---
 kind: Run
 name: import-plenary-minutes
-description: Ad-hoc Import-Job für Plenarprotokolle
+description: Ad-hoc import-Job for Plenarprotokolle
 dependencies:
   - build.import-plenary-minutes
   - deploy.mongo

--- a/services/cron-jobs/sync-procedures/garden.yml
+++ b/services/cron-jobs/sync-procedures/garden.yml
@@ -16,31 +16,30 @@ spec:
   extraFlags: ['--load']
 
 ---
-kind: Deploy
+kind: Run
 name: sync-procedures
-type: kubernetes
-description: Deploy the importer of procedures for the bundestag.io API
-dependencies: [build.sync-procedures, deploy.mongo, deploy.bundestag-io-api]
-
-disabled: ${!(environment.name == "prod" || environment.name == "local-prod")}
+description: Ad-hoc import-Job for Procedures
+dependencies:
+  - build.sync-procedures
+  - deploy.mongo
+  - deploy.bundestag-io-api
 
 variables:
   DB_URL: mongodb://democracy-mongo:27017/democracy
   BUNDESTAGIO_SERVER_URL: http://bundestag-io-api
 
+type: kubernetes-pod
 spec:
-  manifestTemplates:
-    - ./manifests/*
-
-  patchResources:
-    - name: sync-procedures
-      kind: CronJob
-      patch:
-        spec:
-          jobTemplate:
-            spec:
-              template:
-                spec:
-                  containers:
-                    - name: sync-procedures
-                      image: ${actions.build.sync-procedures.outputs.deploymentImageId}
+  podSpec:
+    restartPolicy: Never
+    containers:
+      - name: sync-procedures
+        image: ${actions.build.sync-procedures.outputs.deploymentImageId}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: DB_URL
+            value: ${var.DB_URL}
+          - name: BUNDESTAGIO_SERVER_URL
+            value: ${var.BUNDESTAGIO_SERVER_URL}
+          - name: DEBUG
+            value: '${var.DEBUG || "false"}'

--- a/services/cron-jobs/sync-procedures/manifests/ConfigMap.yaml
+++ b/services/cron-jobs/sync-procedures/manifests/ConfigMap.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: sync-procedures
-data:
-  DB_URL: ${var.DB_URL}
-  BUNDESTAGIO_SERVER_URL: ${var.BUNDESTAGIO_SERVER_URL}


### PR DESCRIPTION
- [import-conference-week-details] add garden files
- [crawler] use env instead of config file
- [desktoop] add missing env vars
- [sync-procedures] refactor to run instead of deploy

This pull request refactors the configuration and deployment setup for several cron job services, moving from Kubernetes `Deploy` actions and ConfigMaps to ad-hoc `Run` actions using Kubernetes pods with explicit environment variable definitions. This change streamlines the configuration process, improves clarity, and enhances control over environment variables for each job. Additionally, a new import job for conference week details is introduced.

**Refactoring deployment and configuration for cron jobs**

* Migrated `crawler` and `sync-procedures` services from Kubernetes `Deploy` actions using ConfigMaps and manifest templates to direct `Run` actions with Kubernetes pods, simplifying the deployment and configuration process. [[1]](diffhunk://#diff-dbe4fa2644f74b5e9e40fbe041ed79a778d439d0e47d18834e958b1110e152b4L1-L20) [[2]](diffhunk://#diff-340f83039f0bc81cc4e2e59f240f1eec5ccd13cf764e95785c54cdc354de7ce4L19-R45)
* Removed the use of external ConfigMaps and secrets for environment variables, now setting all required environment variables directly in the pod specification for each job. [[1]](diffhunk://#diff-dbe4fa2644f74b5e9e40fbe041ed79a778d439d0e47d18834e958b1110e152b4L62-R62) [[2]](diffhunk://#diff-9224507b8131f2428fde3491d486b76da0bf72b70331913d5070b6ec472d05c9L1-L7) [[3]](diffhunk://#diff-340f83039f0bc81cc4e2e59f240f1eec5ccd13cf764e95785c54cdc354de7ce4L19-R45)

**Environment variable handling improvements**

* Added explicit environment variable definitions for each container, including support for optional variables and defaults, improving clarity and flexibility. [[1]](diffhunk://#diff-dbe4fa2644f74b5e9e40fbe041ed79a778d439d0e47d18834e958b1110e152b4L62-R62) [[2]](diffhunk://#diff-6741a952f3a521280a2e8bed992c166ba792bab489e47628f3b12c6c3b0ccdacR1-R47) [[3]](diffhunk://#diff-340f83039f0bc81cc4e2e59f240f1eec5ccd13cf764e95785c54cdc354de7ce4L19-R45)
* Updated `democracy-desktop` container to set `APP_HOST` and `APP_API_URL` environment variables, ensuring correct API connectivity.

**New import job**

* Added a new `import-conference-week-details` cron job with its own build and run actions, including environment variable configuration and dependency management.