### PR TITLE
fix: route native APNs tokens directly via apn package in push-send-q…

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -57,7 +57,7 @@ jobs:
           tags: |
             type=ref,event=branch,enable=${{ github.ref == format('refs/heads/{0}', 'master') || github.ref == format('refs/heads/{0}', 'alpha') || github.ref == format('refs/heads/{0}', 'internal') }}
             type=ref,event=pr
-            type=match,asref=foo,pattern=${{ matrix.package }}@v(\d+.\d+.\d+)(-alpha.\d+)?,group=1
+            type=match,asref=foo,pattern=${{ matrix.package }}@v(\d+.\d+.\d+(?:-alpha.\d+)?),group=1
             type=semver,pattern={{version}},use=foo
             type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
       - name: Print Meta Summary

--- a/services/cron-jobs/push-send-queued/src/index.ts
+++ b/services/cron-jobs/push-send-queued/src/index.ts
@@ -7,6 +7,7 @@ import {
   mongoConnect,
 } from '@democracy-deutschland/democracy-common';
 import admin from 'firebase-admin';
+import apn from 'apn';
 
 admin.initializeApp({
   credential: admin.credential.cert({
@@ -16,6 +17,20 @@ admin.initializeApp({
   }),
 });
 
+const apnsProvider =
+  process.env.APPLE_APN_KEY && process.env.APPLE_APN_KEY_ID && process.env.APPLE_TEAMID
+    ? new apn.Provider({
+        token: {
+          key: process.env.APPLE_APN_KEY.replace(/\\n/gm, '\n'),
+          keyId: process.env.APPLE_APN_KEY_ID,
+          teamId: process.env.APPLE_TEAMID,
+        },
+        production: process.env.NODE_ENV === 'production',
+      })
+    : null;
+
+const isApnsToken = (token: string) => /^[0-9a-f]{64}$/i.test(token);
+
 const getUnsendPushs = async (limit: number) => {
   return PushNotificationModel.find({
     sent: false,
@@ -23,7 +38,25 @@ const getUnsendPushs = async (limit: number) => {
   }).limit(limit);
 };
 
-const sendPush = async (push: Awaited<ReturnType<typeof getUnsendPushs>>[0]) => {
+const sendPushViaApns = async (push: Awaited<ReturnType<typeof getUnsendPushs>>[0]) => {
+  if (!apnsProvider) throw new Error('APNs provider not configured (missing APPLE_APN_KEY, APPLE_APN_KEY_ID or APPLE_TEAMID)');
+  const { type, category, title, message, procedureIds, token } = push;
+
+  const notification = new apn.Notification();
+  notification.expiry = Math.floor(Date.now() / 1000) + 3600;
+  notification.sound = 'push.aiff';
+  notification.alert = { title, body: message };
+  notification.topic = process.env.APN_TOPIC ?? '';
+  notification.payload = { data: { type, action: type, category, title, message, procedureId: procedureIds[0] } };
+
+  const result = await apnsProvider.send(notification, token);
+  if (result.failed.length > 0) {
+    const failure = result.failed[0];
+    throw new Error(failure.response?.reason ?? failure.error?.message ?? 'APNs send failed');
+  }
+};
+
+const sendPushViaFcm = async (push: Awaited<ReturnType<typeof getUnsendPushs>>[0]) => {
   const { type, category, title, message, procedureIds, token } = push;
 
   await admin.messaging().send({
@@ -50,8 +83,16 @@ const sendPush = async (push: Awaited<ReturnType<typeof getUnsendPushs>>[0]) => 
   });
 };
 
+const sendPush = async (push: Awaited<ReturnType<typeof getUnsendPushs>>[0]) => {
+  if (isApnsToken(push.token)) {
+    await sendPushViaApns(push);
+  } else {
+    await sendPushViaFcm(push);
+  }
+};
+
 const handleSendError = async (push: Awaited<ReturnType<typeof getUnsendPushs>>[0], error: unknown) => {
-  console.error('errorASDF', error);
+  console.error('send error', error);
   await DeviceModel.updateMany(
     {
       'pushTokens.token': push.token,
@@ -95,5 +136,6 @@ const start = async () => {
   await mongoConnect();
   console.log("outstanding push's", await PushNotificationModel.countDocuments({ sent: false }));
   await start();
+  apnsProvider?.shutdown();
   process.exit(0);
 })();


### PR DESCRIPTION
…ueued

iOS >= 1.5.5 stores raw APNs device tokens (64-char hex) in the DB. Firebase Admin SDK rejects these as invalid FCM registration tokens.

Detect token format at send time:
- 64-char hex  → sendPushViaApns() using the apn package (already installed)
- all others   → sendPushViaFcm() via Firebase Admin SDK (unchanged)

APNs provider uses existing credentials: APPLE_APN_KEY, APPLE_APN_KEY_ID, APPLE_TEAMID (already in push-notifications-secrets) and APN_TOPIC (already in push-notifications-config).

## Pullrequest

<!-- Describe the Pullrequest. -->

### Issues

<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->

- [x] None

### Checklist

<!-- Anything important to be thought of when deploying?
- [ ] Env-Variables adjustment needed
- [ ] Breaking/critical change
-->

- [x] None

### Repositories Affected

<!-- Did you update any Submodules? -->

- [ ] bundestag.io
- [ ] bundestag.io-admin
- [ ] client
- [ ] democracy-app.de
- [ ] democracy-app.de-api
- [ ] democracy-deutschland.de
- [ ] docu
- [ ] elasticsearch
- [x] None

### How2Test

<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->

- [x] None

### Todo

<!-- In case some parts are still missing, list them here.
- [ ] Todo1
- [ ] Todo2
-->

- [x] None
